### PR TITLE
Hotfix/address string array handling

### DIFF
--- a/TestConsole/Program.cs
+++ b/TestConsole/Program.cs
@@ -1,7 +1,8 @@
-﻿using citizenkraft.UpsStreetAddressValidation.Entities;
+using citizenkraft.UpsStreetAddressValidation.Entities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -11,6 +12,10 @@ namespace TestConsole
 	{
 		static void Main(string[] args)
 		{
+			// Force TLS 1.2 (now required by UPS)
+			ServicePointManager.Expect100Continue = true;
+			ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
 			var validator = new citizenkraft.UpsStreetAddressValidation.UpsStreetAddressValidator("username", "password", "license key", false);
 			//get the response
 			//multiple address candidates

--- a/UpsStreetAddressValidation/Entities/Address.cs
+++ b/UpsStreetAddressValidation/Entities/Address.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using citizenkraft.UpsStreetAddressValidation.Extensions;
 using Newtonsoft.Json;
 
 namespace citizenkraft.UpsStreetAddressValidation.Entities
@@ -10,6 +11,7 @@ namespace citizenkraft.UpsStreetAddressValidation.Entities
 
 	public class Address : IComparable
 	{
+		[JsonConverter(typeof(SingleValueStringArrayConverter))]
 		[JsonProperty("AddressLine")]
 		public string Street { get; set; }
 		[JsonProperty("PoliticalDivision2")]

--- a/UpsStreetAddressValidation/Extensions/SingleValueStringArrayConverter.cs
+++ b/UpsStreetAddressValidation/Extensions/SingleValueStringArrayConverter.cs
@@ -1,0 +1,39 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace citizenkraft.UpsStreetAddressValidation.Extensions
+{
+	public class SingleValueStringArrayConverter : JsonConverter
+	{
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			throw new NotImplementedException();
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType == JsonToken.StartArray)
+            {
+				string[] array = (string[])serializer.Deserialize(reader, Type.GetType("System.String[]"));
+
+				return array[0];
+            }
+
+			return reader.Value.ToString();
+		}
+
+		public override bool CanWrite
+		{
+			get { return false; }
+		}
+
+		public override bool CanConvert(Type objectType)
+		{
+			return true;
+		}
+	}
+}

--- a/UpsStreetAddressValidation/UpsStreetAddressValidation.csproj
+++ b/UpsStreetAddressValidation/UpsStreetAddressValidation.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Entities\XAVRequest.cs" />
     <Compile Include="Entities\XAVResponse.cs" />
     <Compile Include="Extensions\SingleValueArrayConverter.cs" />
+    <Compile Include="Extensions\SingleValueStringArrayConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UpsStreetAddressValidator.cs" />
   </ItemGroup>


### PR DESCRIPTION
UPS's API has a bug in their serializer where for the Street field it may return either `string` or `string[]` similar to Candidate. I wrote a JsonConverter implementation that helps mitigate this by only grabbing the `string[]`'s first value. It'd be easy to change this to do a `String.Join()`, but after seeing what's returned in multi-value situations, the other entries in the array were never useful.